### PR TITLE
Upgrade TypeScript to 5.9.3 and ignore build info files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "globals": "^15.9.0",
         "postcss": "^8.5.15",
         "tailwindcss": "^3.4.10",
-        "typescript": "^5.5.3",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.0",
         "vite": "^8.0.16"
       }
@@ -4402,9 +4402,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "globals": "^15.9.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.10",
-    "typescript": "^5.5.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
     "vite": "^8.0.16"
   }


### PR DESCRIPTION
## Summary
Updates TypeScript to the latest 5.9.x version and adds `.tsbuildinfo` files to `.gitignore` to prevent build artifacts from being tracked in version control.

## Changes
- **TypeScript upgrade**: Bumped from `^5.5.3` to `^5.9.3` to leverage latest language features and improvements
- **Build artifacts**: Added `*.tsbuildinfo` to `.gitignore` to exclude TypeScript incremental build cache files from the repository

## Details
The `.tsbuildinfo` files are generated by TypeScript's incremental build system and are local build artifacts that don't need to be version controlled. This keeps the repository cleaner and prevents merge conflicts from build metadata.

https://claude.ai/code/session_01BgKnD8z3ffr4UqnkE4Gj5N