### PR TITLE
Center project cards horizontally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,11 +180,11 @@ const App: React.FC = () => {
           </header>
 
           <section>
-            <div className="grid gap-4 grid-cols-3 duration-500 md:grid-cols-4 lg:grid-cols-5 ">
+            <div className="flex flex-wrap justify-center gap-4">
               {projects.map((project, index) => (
                 <Card
                   key={index}
-                  className="overflow-hidden cursor-pointer opacity-85 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-[rgba(128,0,0,0.1)] hover:-translate-y-1 hover:rounded-3xl bg-card text-card-foreground border border-border shadow-md"
+                  className="w-32 sm:w-36 shrink-0 overflow-hidden cursor-pointer opacity-85 rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-[rgba(128,0,0,0.1)] hover:-translate-y-1 hover:rounded-3xl bg-card text-card-foreground border border-border shadow-md"
                   onClick={() => window.open(project.url, "_blank")}
                 >
                   <div className={`relative aspect-square ${project.bgClass || ""}`}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The project cards used a fixed CSS grid (`grid-cols-3` / `md:grid-cols-4` / `lg:grid-cols-5`). With four projects, leftover column tracks stayed empty on the right, so the row looked left-aligned under the centered header.

This switches the projects section to a wrapping flex row with `justify-center` and a consistent card width. The group of cards stays horizontally centered, and the last row remains centered if the number of projects changes.

## Visual validation
Opened `http://localhost:5173/` and captured screenshots at three widths. Card-group center matched header center at each size (1200px / 768px / 375px).

**Desktop (1280px)** — four cards in one centered row:
[Desktop 1280px screenshot with centered project cards](https://cursor.com/agents/bc-413ffbdc-8250-4ff1-8d55-8384a1966620/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdesktop-1280.png)

**Tablet (768px)** — four cards still in one centered row:
[Tablet 768px screenshot with centered project cards](https://cursor.com/agents/bc-413ffbdc-8250-4ff1-8d55-8384a1966620/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftablet-768.png)

**Mobile (375px)** — cards wrap to a centered 2×2 layout:
[Mobile 375px screenshot with centered project cards](https://cursor.com/agents/bc-413ffbdc-8250-4ff1-8d55-8384a1966620/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-375.png)

## Test plan
- [x] Open the site and confirm the four project cards are centered under the profile header
- [x] Resize across mobile, tablet, and desktop widths and confirm cards wrap while staying centered
- [ ] Hover a card and confirm the existing lift/shadow/overlay behavior still works
- [ ] Toggle dark mode and confirm card styling is unchanged

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413ffbdc-8250-4ff1-8d55-8384a1966620?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413ffbdc-8250-4ff1-8d55-8384a1966620&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

